### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,9 @@ name: Benchmark
 # and fails if any benchmark is more than 5% slower than the base branch.
 # It compares the ns/op (nanoseconds per operation) metric.
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ryanbekhen/ngebut/security/code-scanning/2](https://github.com/ryanbekhen/ngebut/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow primarily reads repository contents and uploads artifacts, the `contents: read` permission is sufficient. Adding this block at the root level of the workflow ensures that all jobs inherit the same minimal permissions unless explicitly overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
