### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,6 @@
 name: Unit Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ryanbekhen/ngebut/security/code-scanning/1](https://github.com/ryanbekhen/ngebut/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only requires read access to the repository contents, we will set `contents: read` at the root level of the workflow. This ensures that all jobs in the workflow inherit the least privilege necessary unless explicitly overridden.

The changes will be made to the `.github/workflows/unit-tests.yml` file. Specifically:
1. Add a `permissions` block at the root level of the workflow, immediately after the `name` field.
2. Set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
